### PR TITLE
Implement `inside_filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The default value is set to: `proc { |env| true }`.
 This means that every non-`GET` request (which matches the configured `server_name` above) will be
 rewritten to `GET` if the UTF8 parameter is missing.
 
+`FacebookCanvas.inside_filter` is a block called by the middleware to determine whether a request is "inside" (via `FacebookCanvas::Middleware.inside?(request)`) a facebook canvas.
+This might be useful, if your application wants to behave differently whether (or not) a request is coming from facebook canvas.
+
+The default value is set to: `proc { |env| true }`.
+This means that every request is treated as "inside" of a facebook canvas.
+
+
 If you want to use a specific *Secure Canvas URL* (or any other configuration), set the regular expression for `FacebookCanvas.server_name` inside an initializer:
 
 ```ruby
@@ -53,6 +60,11 @@ FacebookCanvas.server_name = /\.fb\./
 # Do not rewrite POST requests from Facebook to "/facebook_realtime_updates"
 FacebookCanvas.custom_filter = proc do |env|
   env['PATH_INFO'] !~ %r{^/facebook_realtime_updates}
+end
+
+# Determine whether a request is "inside" facebook canvas
+FacebookCanvas.inside_filter = proc do |env|
+  # Pull from session or request host or ...
 end
 ```
 

--- a/lib/facebook_canvas.rb
+++ b/lib/facebook_canvas.rb
@@ -4,5 +4,13 @@ require "facebook_canvas/helpers"
 require "facebook_canvas/signed_request"
 
 module FacebookCanvas
-  mattr_accessor :server_name, :custom_filter
+  mattr_accessor :server_name, :custom_filter, :inside_filter
+
+  def self.inside?(env)
+    Middleware.inside?(env)
+  end
+
+  def self.inside!(env)
+    Middleware.inside!(env)
+  end
 end

--- a/lib/facebook_canvas/engine.rb
+++ b/lib/facebook_canvas/engine.rb
@@ -3,7 +3,9 @@ module FacebookCanvas
     initializer "FacebookCanvas.middleware" do |app|
       server_name = FacebookCanvas.server_name || /.*/
       custom_filter = FacebookCanvas.custom_filter || proc { |_env| true }
-      app.config.middleware.use FacebookCanvas::Middleware, server_name, custom_filter
+      inside_filter = FacebookCanvas.inside_filter || proc { |_env| true }
+      app.config.middleware.use FacebookCanvas::Middleware, server_name, custom_filter,
+        inside_filter: inside_filter
 
       ApplicationController.prepend FacebookCanvas::Helpers
     end

--- a/lib/facebook_canvas/middleware.rb
+++ b/lib/facebook_canvas/middleware.rb
@@ -12,23 +12,44 @@
 # Addionally you can restrict `REQUEST_METHOD` rewriting by providing a `custom_filter` block.
 module FacebookCanvas
   class Middleware
-    def initialize(app, request_host, custom_filter)
+    ENV_INSIDE = "facebook_canvas.inside".freeze
+
+    def initialize(app, request_host, custom_filter, inside_filter: nil)
       @app = app
       @request_host = proc_for_request_host(request_host)
       @custom_filter = custom_filter
+      @inside_filter = inside_filter
     end
 
     # Forces REQUEST_METHOD to GET if required.
     def call(env)
-      inside = matches_server_name?(env)
+      inside = match_inside?(env)
 
-      if inside && was_get_request?(env) && !was_xhr_request?(env) && custom_filter?(env)
+      if inside
+        self.class.inside!(env)
+      end
+
+      if inside && matches_server_name?(env) && was_get_request?(env) && !was_xhr_request?(env) && custom_filter?(env)
         env["REQUEST_METHOD"] = "GET"
       end
       @app.call env
     end
 
+    # Check whether current request is marked as "inside Facebook Canvas"
+    def self.inside!(env)
+      env[ENV_INSIDE] = true
+    end
+
+    # Mark current request as "inside Facebook Canvas"
+    def self.inside?(env)
+      env[ENV_INSIDE]
+    end
+
     private
+
+    def match_inside?(env)
+      @inside_filter.nil? || @inside_filter.call(env)
+    end
 
     def proc_for_request_host(request_host)
       case request_host


### PR DESCRIPTION
`FacebookCanvas.inside_filter` is a block called by the middleware to determine whether a request is "inside" (via `FacebookCanvas::Middleware.inside?(request)`) a facebook canvas.
This might be useful, if your application wants to behave differently whether (or not) a request is coming from facebook canvas.

:eyes: @JanOwiesniak @shlub @jnbt 